### PR TITLE
Add support for socket connection and cookie auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ const tc = new TorControl({
   password: 'secure-password'
 });
 
+// Or, if you want to control via Tor Unix socket:
+// const tc = new TorControl({
+//   socketPath: '/var/run/tor/control', // Use unix socket control instead of TCP host
+//   password: 'secure-password'
+//   // cookiePath: '/var/run/tor/control.authcookie', // Set Cookie file for authentication if Tor is running with Cookie Autentication
+// });
+
 tc.connect().then(async () => {
   const { data } = await tc.getNewIdentity();
   console.log(data); // { code: 250, message: 'OK' }

--- a/examples/connect-via-socket-and-cookie.ts
+++ b/examples/connect-via-socket-and-cookie.ts
@@ -1,0 +1,26 @@
+import { TorControl } from 'tor-ctrl';
+
+const tc = new TorControl({
+  socketPath: '/var/run/tor/control', // Use unix socket control instead of TCP host
+  cookiePath: '/var/run/tor/control.authcookie' // Cookie file for authentication
+  // password: 'password' // Set password if Tor is running with Password authentication instead of Cookie Autentication
+});
+
+tc.on('connect', () => {
+  console.log('Connected!');
+});
+
+tc.on('error', (err) => {
+  console.error('Error:', err);
+});
+
+tc.on('close', () => {
+  console.log('Closed!');
+});
+
+tc.connect()
+  .then(async () => {
+    const { data } = await tc.sendCommand(['GETINFO', 'version']);
+    console.log('GETINFO:', data); // [ { code: 250, message: 'version=...' } ]
+  })
+  .finally(() => tc.disconnect());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { Result, ResultList, SafeReturn, Signal, TorControlConfig } from '@/types';
 import { EventEmitter } from 'node:events';
 import { connect, Socket } from 'node:net';
+import fs from 'node:fs';
 
 class TorControl extends EventEmitter {
   private _connection: Socket | null = null;
@@ -49,7 +50,9 @@ class TorControl extends EventEmitter {
    */
   connect() {
     // Use TOR ControlSocket (Unix socket) setting if it was set or otherwise use TOR TCP ControlPort setting
-    const conn = this._config.socketPath ? connect(this._config.socketPath) : connect({ port: this._config.port, host: this._config.host });
+    const conn = this._config.socketPath
+      ? connect(this._config.socketPath)
+      : connect({ port: this._config.port, host: this._config.host });
     this._connection = conn;
 
     return new Promise<SafeReturn<boolean, Error>>((resolve) => {
@@ -84,6 +87,13 @@ class TorControl extends EventEmitter {
       // Auth
       if (this._config.password) {
         this.authenticate(this._config.password).then(({ error }) => {
+          if (error) {
+            this.emit('error', error);
+            return resolve({ error });
+          }
+        });
+      } else if (this._config.cookiePath) {
+        this.authenticateWithCookie(this._config.cookiePath).then(({ error }) => {
           if (error) {
             this.emit('error', error);
             return resolve({ error });
@@ -195,6 +205,25 @@ class TorControl extends EventEmitter {
     return this._solveAndPick(this.sendCommand(`AUTHENTICATE "${password}"`));
   }
 
+  /**
+   * Authenticate using the cookie file
+   * @link https://spec.torproject.org/control-spec/commands.html?highlight=AUTHENTICATE#authenticate
+   * @param cookiePath
+   */
+  async authenticateWithCookie(cookiePath: string): Promise<SafeReturn<Result, Error>> {
+    try {
+      // Read the cookie file
+      const cookieBuffer: Buffer = fs.readFileSync(cookiePath);
+
+      // Convert the buffer to a hexadecimal string
+      const cookie = cookieBuffer.toString('hex').trim();
+
+      // Send the AUTHENTICATE command with the cookie
+      return this._solveAndPick(this.sendCommand(`AUTHENTICATE ${cookie}`));
+    } catch (error: Error | any) {
+      return { error: new Error(`Failed to read cookie file: ${error.message}`) };
+    }
+  }
   /**
    * Quit
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,8 @@ class TorControl extends EventEmitter {
    * Establish a connection to the TorControl
    */
   connect() {
-    const conn = connect(this._config.port, this._config.host);
+    // Use TOR ControlSocket (Unix socket) setting if it was set or otherwise use TOR TCP ControlPort setting
+    const conn = this._config.socketPath ? connect(this._config.socketPath) : connect({ port: this._config.port, host: this._config.host });
     this._connection = conn;
 
     return new Promise<SafeReturn<boolean, Error>>((resolve) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { Result, ResultList, SafeReturn, Signal, TorControlConfig } from '@/types';
 import { EventEmitter } from 'node:events';
 import { connect, Socket } from 'node:net';
-import fs from 'node:fs';
+import { promises } from 'node:fs';
 
 class TorControl extends EventEmitter {
   private _connection: Socket | null = null;
@@ -213,7 +213,7 @@ class TorControl extends EventEmitter {
   async authenticateWithCookie(cookiePath: string): Promise<SafeReturn<Result, Error>> {
     try {
       // Read the cookie file
-      const cookieBuffer: Buffer = fs.readFileSync(cookiePath);
+      const cookieBuffer = await promises.readFile(cookiePath);
 
       // Convert the buffer to a hexadecimal string
       const cookie = cookieBuffer.toString('hex').trim();

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface TorControlConfig {
   port: number;
   password: string | undefined;
   socketPath: string | undefined;
+  cookiePath: string | undefined;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface TorControlConfig {
   host: string;
   port: number;
   password: string | undefined;
+  socketPath: string | undefined;
 }
 
 /**


### PR DESCRIPTION
Hi @shahradelahi , thank you for mantaining this package.

This PR will introduce new features:
- Support of [tor control using socket connection (ControlSocket)](https://github.com/shahradelahi/node-tor-control/commit/6d0ea17581d98031ce451384a93059178e4628f3)
- [Tor control auth using CookieAuthentication file](https://github.com/shahradelahi/node-tor-control/commit/a3d5c0feb7c3531ec9c1573b0d18dc81293404ec)

To test this, we can run TOR instance with configuration such as:
```cli
mkdir -p /tmp/tor-instance-example && \
chmod 700 /tmp/tor-instance-example && \
tor --DataDirectory /tmp/tor-instance-example \
    --ControlSocket /tmp/tor-instance-example/control \
    --CookieAuthentication 1 \
    --SocksPort 9052
```

Example code was also added in `examples` directory and can be adjusted manually with configuration above.

Let me know if there are additional changes that will be needed. Thank you.